### PR TITLE
refactor: use graasp sdk limits, filter out using one query

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "fastify": "^3.29.1",
     "graasp-item-tags": "github:graasp/graasp-item-tags",
-    "graasp-test": "github:graasp/graasp-test",
+    "graasp-test": "github:graasp/graasp-test#25-item-type",
     "husky": "7.0.4",
     "jest": "^27.4.7",
     "prettier": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "fastify": "^3.29.1",
     "graasp-item-tags": "github:graasp/graasp-item-tags",
-    "graasp-test": "github:graasp/graasp-test#25-item-type",
+    "graasp-test": "github:graasp/graasp-test",
     "husky": "7.0.4",
     "jest": "^27.4.7",
     "prettier": "^2.5.1",

--- a/src/db-service.ts
+++ b/src/db-service.ts
@@ -115,7 +115,7 @@ export class RecycledItemService {
    */
   async isDeleted(itemPath: string, transactionHandler: TrxHandler): Promise<boolean> {
     return transactionHandler
-      .query<Pick<Item, 'id'>>(
+      .query<string>(
         sql`
         SELECT id
         FROM recycled_item
@@ -123,5 +123,21 @@ export class RecycledItemService {
       `,
       )
       .then(({ rows }) => Boolean(rows.length));
+  }
+
+  /**
+   * Get item ids are deleted
+   * @param transactionHandler Database transaction handler
+   */
+  async areDeleted(itemPaths: string[], transactionHandler: TrxHandler): Promise<string[]> {
+    return transactionHandler
+      .query<string>(
+        sql`
+        SELECT id
+        FROM recycled_item
+        WHERE item_path @> ${itemPaths}
+      `,
+      )
+      .then(({ rows }) => rows.slice(0));
   }
 }

--- a/src/db-service.ts
+++ b/src/db-service.ts
@@ -115,7 +115,7 @@ export class RecycledItemService {
    */
   async isDeleted(itemPath: string, transactionHandler: TrxHandler): Promise<boolean> {
     return transactionHandler
-      .query<string>(
+      .query<Pick<Item, 'id'>>(
         sql`
         SELECT id
         FROM recycled_item
@@ -129,13 +129,21 @@ export class RecycledItemService {
    * Get item ids are deleted
    * @param transactionHandler Database transaction handler
    */
-  async areDeleted(itemPaths: string[], transactionHandler: TrxHandler): Promise<string[]> {
+  async areDeleted(
+    itemPaths: string[],
+    transactionHandler: TrxHandler,
+  ): Promise<Pick<Item, 'path'>[]> {
+    const whereCondition = sql.join(
+      itemPaths.map((path) => sql`item_path @> ${path}`),
+      sql` OR `,
+    );
+
     return transactionHandler
-      .query<string>(
+      .query<Pick<Item, 'path'>>(
         sql`
-        SELECT id
+        SELECT item_path as path
         FROM recycled_item
-        WHERE item_path @> ${itemPaths}
+        WHERE ${whereCondition}
       `,
       )
       .then(({ rows }) => rows.slice(0));

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -66,7 +66,7 @@ const plugin: FastifyPluginAsync<RecycleBinOptions> = async (fastify, options) =
       db.pool,
     );
     const filteredItems = items.map((item) => {
-      return recycledItems.find((id) => id === item.id) ? null : item;
+      return recycledItems.find(({ path }) => item.path.includes(path)) ? null : item;
     });
 
     // split for in-place changes in the array
@@ -136,8 +136,10 @@ const plugin: FastifyPluginAsync<RecycleBinOptions> = async (fastify, options) =
         db.pool,
       );
       const filteredItems = items.map((item) => {
-        const itemId = (item as Item).id;
-        return recycledItems.find((id) => id === itemId) ? new CannotGetRecycledItem(itemId) : item;
+        const itemPath = (item as Item).path;
+        return recycledItems.find(({ path }) => itemPath.includes(path))
+          ? new CannotGetRecycledItem(itemPath)
+          : item;
       });
       // split for in-place changes in the array
       items.splice(0, items.length, ...filteredItems.filter(Boolean));

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -60,6 +60,9 @@ const plugin: FastifyPluginAsync<RecycleBinOptions> = async (fastify, options) =
   fastify.addSchema(common);
 
   const removeRecycledItems = async (items) => {
+    if (!items || !items.length) {
+      return;
+    }
     // get recycled ids from given item paths and filter them out
     const recycledItems = await recycledItemService.areDeleted(
       items.map(({ path }) => path),

--- a/src/task-manager.ts
+++ b/src/task-manager.ts
@@ -17,7 +17,11 @@ import { GetOwnRecycledItemsTask } from './tasks/get-own-recycled-items-task';
 import { IsItemDeletedTask } from './tasks/is-item-deleted-task';
 
 export class TaskManager implements RecycledItemTaskManager<Member> {
-  private recycledItemService = new RecycledItemService();
+  private recycledItemService: RecycledItemService;
+
+  constructor(recycledItemService: RecycledItemService) {
+    this.recycledItemService = recycledItemService;
+  }
 
   getOwnTaskName(): string {
     return GetOwnRecycledItemsTask.name;

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -119,6 +119,22 @@ describe('Plugin Tests', () => {
 
         await build({ itemTaskManager, runner, itemMembershipTaskManager });
       });
+      it('Pass for empty items', async () => {
+        jest.spyOn(runner, 'setTaskPreHookHandler').mockImplementation(async () => false);
+        jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
+          const items = [];
+          if (name === itemTaskManager.getGetOwnTaskName()) {
+            // only folder item is deleted
+            jest
+              .spyOn(RecycledItemService.prototype, 'areDeleted')
+              .mockImplementation(async () => []);
+            await fn(items, actor, { log: MOCK_LOGGER });
+            expect(items).toEqual([]);
+          }
+        });
+
+        await build({ itemTaskManager, runner, itemMembershipTaskManager });
+      });
     });
     describe('Get Children Post Hook Handler', () => {
       it('Filter items on get children', async () => {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -110,11 +110,8 @@ describe('Plugin Tests', () => {
           if (name === itemTaskManager.getGetOwnTaskName()) {
             // only folder item is deleted
             jest
-              .spyOn(RecycledItemService.prototype, 'isDeleted')
-              .mockImplementation(async () => true);
-            jest.spyOn(runner, 'runSingle').mockImplementation(async (task) => {
-              return (task.input as { item: Item })?.item.path === deletedItem.path;
-            });
+              .spyOn(RecycledItemService.prototype, 'areDeleted')
+              .mockImplementation(async () => [deletedItem.id]);
             await fn(items, actor, { log: MOCK_LOGGER });
             expect(items.length).toEqual(ITEMS.length - 1);
             expect(items).toEqual(ITEMS.slice(1));
@@ -133,11 +130,8 @@ describe('Plugin Tests', () => {
           if (name === itemTaskManager.getGetChildrenTaskName()) {
             // only folder item is deleted
             jest
-              .spyOn(RecycledItemService.prototype, 'isDeleted')
-              .mockImplementation(async () => true);
-            jest.spyOn(runner, 'runSingle').mockImplementation(async (task) => {
-              return (task.input as { item: Item })?.item.path === deletedItem.path;
-            });
+              .spyOn(RecycledItemService.prototype, 'areDeleted')
+              .mockImplementation(async () => [deletedItem.id]);
             await fn(items, actor, { log: MOCK_LOGGER });
             expect(items.length).toEqual(ITEMS.length - 1);
             expect(items).toEqual(ITEMS.slice(1));
@@ -156,11 +150,8 @@ describe('Plugin Tests', () => {
           if (name === itemTaskManager.getGetDescendantsTaskName()) {
             // only folder item is deleted
             jest
-              .spyOn(RecycledItemService.prototype, 'isDeleted')
-              .mockImplementation(async () => true);
-            jest.spyOn(runner, 'runSingle').mockImplementation(async (task) => {
-              return (task.input as { item: Item })?.item.path === deletedItem.path;
-            });
+              .spyOn(RecycledItemService.prototype, 'areDeleted')
+              .mockImplementation(async () => [deletedItem.id]);
             await fn(items, actor, { log: MOCK_LOGGER });
             expect(items.length).toEqual(ITEMS.length - 1);
             expect(items).toEqual(ITEMS.slice(1));
@@ -179,11 +170,8 @@ describe('Plugin Tests', () => {
           if (name === itemTaskManager.getGetSharedWithTaskName()) {
             // only folder item is deleted
             jest
-              .spyOn(RecycledItemService.prototype, 'isDeleted')
-              .mockImplementation(async () => true);
-            jest.spyOn(runner, 'runSingle').mockImplementation(async (task) => {
-              return (task.input as { item: Item })?.item.path === deletedItem.path;
-            });
+              .spyOn(RecycledItemService.prototype, 'areDeleted')
+              .mockImplementation(async () => [deletedItem.id]);
             await fn(items, actor, { log: MOCK_LOGGER });
             expect(items.length).toEqual(ITEMS.length - 1);
             expect(items).toEqual(ITEMS.slice(1));
@@ -239,11 +227,8 @@ describe('Plugin Tests', () => {
           if (name === itemTaskManager.getGetManyTaskName()) {
             // only folder item is deleted
             jest
-              .spyOn(RecycledItemService.prototype, 'isDeleted')
-              .mockImplementation(async () => true);
-            jest.spyOn(runner, 'runSingle').mockImplementation(async (task) => {
-              return (task.input as { item: Item })?.item.path === deletedItem.path;
-            });
+              .spyOn(RecycledItemService.prototype, 'areDeleted')
+              .mockImplementation(async () => [deletedItem.id]);
             await fn(items, actor, { log: MOCK_LOGGER });
             expect(items.length).toEqual(ITEMS.length);
             expect(items[0]).toEqual(new CannotGetRecycledItem(deletedItem.id));

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -105,13 +105,13 @@ describe('Plugin Tests', () => {
       it('Filter items on get own items', async () => {
         jest.spyOn(runner, 'setTaskPreHookHandler').mockImplementation(async () => false);
         jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
-          const deletedItem = ITEM_FOLDER;
+          const deletedItemPath = ITEM_FOLDER.path;
           const items = [...ITEMS];
           if (name === itemTaskManager.getGetOwnTaskName()) {
             // only folder item is deleted
             jest
               .spyOn(RecycledItemService.prototype, 'areDeleted')
-              .mockImplementation(async () => [deletedItem.id]);
+              .mockImplementation(async () => [{ path: deletedItemPath }]);
             await fn(items, actor, { log: MOCK_LOGGER });
             expect(items.length).toEqual(ITEMS.length - 1);
             expect(items).toEqual(ITEMS.slice(1));
@@ -125,13 +125,13 @@ describe('Plugin Tests', () => {
       it('Filter items on get children', async () => {
         jest.spyOn(runner, 'setTaskPreHookHandler').mockImplementation(async () => false);
         jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
-          const deletedItem = ITEM_FOLDER;
+          const deletedItemPath = ITEM_FOLDER.path;
           const items = [...ITEMS];
           if (name === itemTaskManager.getGetChildrenTaskName()) {
             // only folder item is deleted
             jest
               .spyOn(RecycledItemService.prototype, 'areDeleted')
-              .mockImplementation(async () => [deletedItem.id]);
+              .mockImplementation(async () => [{ path: deletedItemPath }]);
             await fn(items, actor, { log: MOCK_LOGGER });
             expect(items.length).toEqual(ITEMS.length - 1);
             expect(items).toEqual(ITEMS.slice(1));
@@ -145,13 +145,13 @@ describe('Plugin Tests', () => {
       it('Filter items on get descendants', async () => {
         jest.spyOn(runner, 'setTaskPreHookHandler').mockImplementation(async () => false);
         jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
-          const deletedItem = ITEM_FOLDER;
+          const deletedItemPath = ITEM_FOLDER.path;
           const items = [...ITEMS];
           if (name === itemTaskManager.getGetDescendantsTaskName()) {
             // only folder item is deleted
             jest
               .spyOn(RecycledItemService.prototype, 'areDeleted')
-              .mockImplementation(async () => [deletedItem.id]);
+              .mockImplementation(async () => [{ path: deletedItemPath }]);
             await fn(items, actor, { log: MOCK_LOGGER });
             expect(items.length).toEqual(ITEMS.length - 1);
             expect(items).toEqual(ITEMS.slice(1));
@@ -165,13 +165,13 @@ describe('Plugin Tests', () => {
       it('Filter items on get shared items', async () => {
         jest.spyOn(runner, 'setTaskPreHookHandler').mockImplementation(async () => false);
         jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
-          const deletedItem = ITEM_FOLDER;
+          const deletedItemPath = ITEM_FOLDER.path;
           const items = [...ITEMS];
           if (name === itemTaskManager.getGetSharedWithTaskName()) {
             // only folder item is deleted
             jest
               .spyOn(RecycledItemService.prototype, 'areDeleted')
-              .mockImplementation(async () => [deletedItem.id]);
+              .mockImplementation(async () => [{ path: deletedItemPath }]);
             await fn(items, actor, { log: MOCK_LOGGER });
             expect(items.length).toEqual(ITEMS.length - 1);
             expect(items).toEqual(ITEMS.slice(1));
@@ -222,16 +222,16 @@ describe('Plugin Tests', () => {
       it('Replace items with errors if deleted on get many items', async () => {
         jest.spyOn(runner, 'setTaskPreHookHandler').mockImplementation(async () => false);
         jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
-          const deletedItem = ITEM_FOLDER;
+          const deletedItemPath = ITEM_FOLDER.path;
           const items = [...ITEMS];
           if (name === itemTaskManager.getGetManyTaskName()) {
             // only folder item is deleted
             jest
               .spyOn(RecycledItemService.prototype, 'areDeleted')
-              .mockImplementation(async () => [deletedItem.id]);
+              .mockImplementation(async () => [{ path: deletedItemPath }]);
             await fn(items, actor, { log: MOCK_LOGGER });
             expect(items.length).toEqual(ITEMS.length);
-            expect(items[0]).toEqual(new CannotGetRecycledItem(deletedItem.id));
+            expect(items[0]).toEqual(new CannotGetRecycledItem(deletedItemPath));
             expect(items[1]).toEqual(ITEMS[1]);
           }
         });

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -4,7 +4,6 @@ import { v4 } from 'uuid';
 
 import { FastifyLoggerInstance } from 'fastify';
 
-import { Item } from '@graasp/sdk';
 import { ItemMembershipTaskManager, ItemTaskManager, TaskRunner } from 'graasp-test';
 
 import { RecycledItemService } from '../src/db-service';

--- a/test/app.ts
+++ b/test/app.ts
@@ -1,6 +1,11 @@
 import fastify from 'fastify';
 
-import { Item, ItemMembershipTaskManager, TaskRunner } from '@graasp/sdk';
+import {
+  DatabaseTransactionHandler,
+  Item,
+  ItemMembershipTaskManager,
+  TaskRunner,
+} from '@graasp/sdk';
 import { ItemTaskManager } from 'graasp-test';
 
 import plugin, { RecycleBinOptions } from '../src/plugin';
@@ -45,6 +50,10 @@ const build = async ({
   });
   app.decorate('itemMemberships', {
     taskManager: itemMembershipTaskManager,
+  });
+
+  app.decorate('db', {
+    pool: {} as unknown as DatabaseTransactionHandler,
   });
 
   await app.register(plugin, options);

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,13 +1,13 @@
 import { v4 } from 'uuid';
 
-import { Actor, Item } from '@graasp/sdk';
+import { Actor, Item, ItemType } from '@graasp/sdk';
 
 export const ITEM_FILE: Item = {
   id: v4(),
   description: '',
   path: 'some_path',
   name: 'item-file',
-  type: 'file',
+  type: ItemType.LOCAL_FILE,
   extra: {
     file: {},
   },
@@ -23,9 +23,9 @@ export const ITEM_FILE: Item = {
 export const ITEM_FOLDER: Item = {
   id: v4(),
   description: '',
-  path: 'some_folder_path',
+  path: 'some_folder_path_0',
   name: 'item-folder',
-  type: 'folder',
+  type: ItemType.FOLDER,
   extra: {},
   creator: 'creator-id',
   createdAt: 'somedata',
@@ -47,7 +47,7 @@ export const ITEMS: Item[] = [
     description: '',
     path: 'some_folder_path_1',
     name: 'item-folder',
-    type: 'folder',
+    type: ItemType.FOLDER,
     extra: {},
     creator: 'creator-id',
     createdAt: 'somedata',
@@ -62,7 +62,7 @@ export const ITEMS: Item[] = [
     description: '',
     path: 'some_folder_path_2',
     name: 'item-folder',
-    type: 'folder',
+    type: ItemType.FOLDER,
     extra: {},
     creator: 'creator-id',
     createdAt: 'somedata',

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,17 +843,18 @@ __metadata:
 
 "@graasp/sdk@github:graasp/graasp-sdk":
   version: 0.1.0
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=7e3491095507f6dfd129d318a87e6c63f0eb486e"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=4fa31e8d473b13bfa0bad3e10da9e7b9ca4f20d5"
   dependencies:
     "@fastify/secure-session": 5.2.0
     aws-sdk: 2.1111.0
     fastify: ^3.29.1
     fluent-json-schema: 3.1.0
+    immutable: 4.1.0
     js-cookie: 3.0.1
     qs: 6.11.0
     slonik: 28.1.1
     uuid: 8.3.2
-  checksum: 1fdf3b5c52945769005bb6a83620a09f8995f5d16b2115675a7cf745b2a02e07758b3ed1a77b9357b0a9d6ab984e5427a18e4a5353e04f4d02ce16c2010e9785
+  checksum: 9af6a948678de50d9ae48792982e340d9aafd20e528185b4d34f8e54df7374573d011843741faabf5197cb8d73cf2fbadf033998937a313ceed61295f013dbc8
   languageName: node
   linkType: hard
 
@@ -3689,6 +3690,13 @@ __metadata:
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
   checksum: 6b1f926792d614f64c6c83da3a1f9c83f6196c2839aa41e1e32dd7b8d174cef2e329d75caabb62cb61ce9dc432f75e67d07d122a037312db7caa73166a1bdb77
+  languageName: node
+  linkType: hard
+
+"immutable@npm:4.1.0":
+  version: 4.1.0
+  resolution: "immutable@npm:4.1.0"
+  checksum: b9bc1f14fb18eb382d48339c064b24a1f97ae4cf43102e0906c0a6e186a27afcd18b55ca4a0b63c98eefb58143e2b5ebc7755a5fb4da4a7ad84b7a6096ac5b13
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3458,7 +3458,7 @@ __metadata:
     eslint-plugin-prettier: ^4.0.0
     fastify: ^3.29.1
     graasp-item-tags: "github:graasp/graasp-item-tags"
-    graasp-test: "github:graasp/graasp-test"
+    graasp-test: "github:graasp/graasp-test#25-item-type"
     http-status-codes: ^2.2.0
     husky: 7.0.4
     jest: ^27.4.7
@@ -3472,12 +3472,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"graasp-test@github:graasp/graasp-test":
+"graasp-test@github:graasp/graasp-test#25-item-type":
   version: 0.1.0
-  resolution: "graasp-test@https://github.com/graasp/graasp-test.git#commit=3ff1f7951d1c2439f84fab546bf8de60b530bd1c"
+  resolution: "graasp-test@https://github.com/graasp/graasp-test.git#commit=2f3a238506012be0da80b5ac899b4e13dd4c887d"
   dependencies:
     uuid: 8.3.2
-  checksum: aaa3759fe2842de03fdc99011623dced835636fe5e15598c8574b9d526c040615dac3bf06fd351007a07d267493f9cd4e70c14ef35b0b73fb2810f90be4bbae8
+  checksum: e4fcc3e4a9434bb590f26610c3d2bdff4f493e4b9257e947eb485649580acbccad4cf100f9335fe1f061b89bbe1209a1bea0ce5d5337af5f1ed6c619915d669f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3458,7 +3458,7 @@ __metadata:
     eslint-plugin-prettier: ^4.0.0
     fastify: ^3.29.1
     graasp-item-tags: "github:graasp/graasp-item-tags"
-    graasp-test: "github:graasp/graasp-test#25-item-type"
+    graasp-test: "github:graasp/graasp-test"
     http-status-codes: ^2.2.0
     husky: 7.0.4
     jest: ^27.4.7
@@ -3472,9 +3472,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"graasp-test@github:graasp/graasp-test#25-item-type":
+"graasp-test@github:graasp/graasp-test":
   version: 0.1.0
-  resolution: "graasp-test@https://github.com/graasp/graasp-test.git#commit=2f3a238506012be0da80b5ac899b4e13dd4c887d"
+  resolution: "graasp-test@https://github.com/graasp/graasp-test.git#commit=dd6ca72cf4be7483c9232f99d17186e7c441c601"
   dependencies:
     uuid: 8.3.2
   checksum: e4fcc3e4a9434bb590f26610c3d2bdff4f493e4b9257e947eb485649580acbccad4cf100f9335fe1f061b89bbe1209a1bea0ce5d5337af5f1ed6c619915d669f


### PR DESCRIPTION
This PR updates the hooks when triggered for multiple items: we avoid doing n query for n items (freeing more connection to the db pool).

close #38 
close #37 